### PR TITLE
Fix missing cover image in WhatsApp sticker exports

### DIFF
--- a/src/sticker_convert/uploaders/compress_wastickers.py
+++ b/src/sticker_convert/uploaders/compress_wastickers.py
@@ -129,6 +129,7 @@ class CompressWastickers(UploadBase):
 
                 assert isinstance(cover_data, bytes)
                 zipf.writestr("tray.png", cover_data)
+                zipf.writestr("cover.png", cover_data)
                 zipf.write(Path(self.opt_output.dir, "author.txt"), "author.txt")
                 zipf.write(Path(self.opt_output.dir, "title.txt"), "title.txt")
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import zipfile
 from pathlib import Path
 from typing import List, Optional
 
@@ -172,6 +173,10 @@ def test_export_wastickers(tmp_path: LocalPath) -> None:
 
     wastickers_path = Path(tmp_path, "sticker-convert-test.wastickers")
     assert Path(wastickers_path).is_file()
+    with zipfile.ZipFile(wastickers_path) as zf:
+        assert "tray.png" in zf.namelist()
+        assert "cover.png" in zf.namelist()
+        assert zf.read("tray.png") == zf.read("cover.png")
 
 
 def test_export_line(tmp_path: LocalPath) -> None:


### PR DESCRIPTION
## Summary
- write `cover.png` alongside the existing `tray.png` when exporting `.wastickers`
- keep both files byte-identical so older or stricter consumers can still find the tray art
- add a regression test that verifies both files are present in the exported archive

## Testing
- smoke-tested WhatsApp export and verified the generated archive contains both `tray.png` and `cover.png`

Fixes #205.