### PR TITLE
Add Misskey pack import and export support

### DIFF
--- a/src/sticker_convert/cli.py
+++ b/src/sticker_convert/cli.py
@@ -245,6 +245,7 @@ class CLI:
             "viber": args.download_viber,
             "discord": args.download_discord,
             "discord_emoji": args.download_discord_emoji,
+            "misskey": args.download_misskey,
         }
 
         download_option = "local"
@@ -293,6 +294,8 @@ class CLI:
             export_option = "viber"
         elif args.export_imessage:
             export_option = "imessage"
+        elif args.export_misskey:
+            export_option = "misskey"
         else:
             export_option = "local"
 
@@ -321,6 +324,7 @@ class CLI:
                         args.export_telegram_emoji_telethon,
                         args.export_viber,
                         args.export_imessage,
+                        args.export_misskey,
                     )
                 )
                 > 1
@@ -339,6 +343,8 @@ class CLI:
                 preset = "viber"
             elif args.export_imessage:
                 preset = "imessage_small"
+            elif args.export_misskey:
+                preset = "misskey"
         elif args.preset == "auto":
             msg_base = I("Auto compression option set to {}")
             output_option = (
@@ -359,6 +365,9 @@ class CLI:
                 self.cb.put(msg_base.format(preset))
             elif output_option == "imessage":
                 preset = "imessage_small"
+                self.cb.put(msg_base.format(preset))
+            elif output_option == "misskey":
+                preset = "misskey"
                 self.cb.put(msg_base.format(preset))
             else:
                 preset = output_option

--- a/src/sticker_convert/downloaders/download_misskey.py
+++ b/src/sticker_convert/downloaders/download_misskey.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+import json
+import re
+import unicodedata
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from sticker_convert.downloaders.download_base import DownloadBase
+from sticker_convert.job_option import CredOption, InputOption
+from sticker_convert.utils.callback import CallbackProtocol, CallbackReturn
+from sticker_convert.utils.files.metadata_handler import MetadataHandler
+from sticker_convert.utils.files.sanitize_filename import sanitize_filename
+from sticker_convert.utils.translate import I
+
+
+class DownloadMisskey(DownloadBase):
+    @staticmethod
+    def _slugify(value: str) -> str:
+        normalized = unicodedata.normalize("NFKD", value)
+        ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+        slug = re.sub(r"[^a-zA-Z0-9_]+", "_", ascii_value).strip("_").lower()
+        return slug
+
+    def _find_archive(self) -> Tuple[bytes, str]:
+        response = requests.get(self.url, allow_redirects=True)
+        if not response.ok:
+            self.cb.put(I("Download failed: Cannot download {}").format(self.url))
+            return b"", ""
+
+        final_url = response.url
+        content_type = response.headers.get("content-type", "").lower()
+        if (
+            final_url.lower().endswith(".zip")
+            or "application/zip" in content_type
+            or response.content.startswith(b"PK\x03\x04")
+        ):
+            return response.content, final_url
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        zip_link = None
+        for link in soup.find_all("a", href=True):
+            href = str(link["href"])
+            if href.lower().endswith(".zip"):
+                zip_link = urljoin(final_url, href)
+                break
+
+        if zip_link is None:
+            self.cb.put(I("Download failed: Cannot find Misskey ZIP archive"))
+            return b"", ""
+
+        archive = self.download_file(zip_link, show_progress=False)
+        return archive, zip_link
+
+    def _get_unique_path(self, stem: str, suffix: str) -> Path:
+        candidate = sanitize_filename(f"{stem}{suffix}")
+        if candidate in ("", "__"):
+            candidate = sanitize_filename(f"emoji{suffix}")
+
+        out_path = self.out_dir / candidate
+        counter = 2
+        while out_path.exists():
+            out_path = self.out_dir / sanitize_filename(f"{stem}_{counter}{suffix}")
+            counter += 1
+
+        return out_path
+
+    def download_stickers_misskey(self) -> Tuple[int, int]:
+        archive_bytes, archive_url = self._find_archive()
+        if not archive_bytes:
+            return 0, 0
+
+        with zipfile.ZipFile(BytesIO(archive_bytes)) as zf:
+            meta_path = next(
+                (name for name in zf.namelist() if Path(name).name == "meta.json"),
+                None,
+            )
+            if meta_path is None:
+                self.cb.put(I("Download failed: meta.json is missing in archive"))
+                return 0, 0
+
+            meta = json.loads(zf.read(meta_path))
+            emojis = meta.get("emojis", [])
+            if not isinstance(emojis, list):
+                self.cb.put(I("Download failed: Invalid Misskey meta.json"))
+                return 0, 0
+
+            self.cb.put(
+                (
+                    "bar",
+                    None,
+                    {"set_progress_mode": "determinate", "steps": len(emojis)},
+                )
+            )
+
+            extracted = 0
+            names_seen = set()
+            for entry in emojis:
+                if not entry.get("downloaded", True):
+                    self.cb.put("update_bar")
+                    continue
+
+                file_name = entry.get("fileName")
+                if not isinstance(file_name, str):
+                    self.cb.put("update_bar")
+                    continue
+
+                try:
+                    data = zf.read(file_name)
+                except KeyError:
+                    self.cb.put(I("Warning: {} is missing from archive").format(file_name))
+                    self.cb.put("update_bar")
+                    continue
+
+                emoji_meta = entry.get("emoji", {})
+                emoji_name = ""
+                if isinstance(emoji_meta, dict):
+                    emoji_name = str(emoji_meta.get("name", "")).strip()
+
+                stem = self._slugify(emoji_name) or self._slugify(Path(file_name).stem)
+                if not stem:
+                    stem = f"emoji_{str(extracted + 1).zfill(3)}"
+                if stem in names_seen:
+                    stem = f"{stem}_{str(extracted + 1).zfill(3)}"
+                names_seen.add(stem)
+
+                out_path = self._get_unique_path(stem, Path(file_name).suffix.lower())
+                with open(out_path, "wb+") as f:
+                    f.write(data)
+
+                self.cb.put(I("Downloaded {}").format(out_path.name))
+                extracted += 1
+                self.cb.put("update_bar")
+
+        archive_title = Path(archive_url).stem.replace(".tar", "")
+        if archive_title:
+            archive_title = archive_title.replace("_", " ").replace("-", " ").strip()
+        MetadataHandler.set_metadata(
+            self.out_dir,
+            title=archive_title or self.out_dir.name,
+            author=str(meta.get("host", "")).strip(),
+        )
+
+        return extracted, extracted
+
+    @staticmethod
+    def start(
+        opt_input: InputOption,
+        opt_cred: Optional[CredOption],
+        cb: CallbackProtocol,
+        cb_return: CallbackReturn,
+    ) -> Tuple[int, int]:
+        downloader = DownloadMisskey(opt_input, opt_cred, cb, cb_return)
+        return downloader.download_stickers_misskey()

--- a/src/sticker_convert/job.py
+++ b/src/sticker_convert/job.py
@@ -645,6 +645,11 @@ class Job:
 
             downloaders.append(DownloadDiscord.start)
 
+        if self.opt_input.option == "misskey":
+            from sticker_convert.downloaders.download_misskey import DownloadMisskey
+
+            downloaders.append(DownloadMisskey.start)
+
         if len(downloaders) > 0:
             self.executor.cb(I("Downloading..."))
         else:
@@ -812,6 +817,11 @@ class Job:
             from sticker_convert.uploaders.upload_viber import UploadViber
 
             exporters.append(UploadViber.start)
+
+        if self.opt_output.option == "misskey":
+            from sticker_convert.uploaders.compress_misskey import CompressMisskey
+
+            exporters.append(CompressMisskey.start)
 
         self.executor.start_workers(processes=1)
 

--- a/src/sticker_convert/resources/compression.json
+++ b/src/sticker_convert/resources/compression.json
@@ -587,6 +587,55 @@
         "quantize_method": "imagequant",
         "default_emoji": "😀"
     },
+    "misskey": {
+        "size_max": {
+            "img": 50000,
+            "vid": 50000
+        },
+        "format": {
+            "img": ".png",
+            "vid": ".gif"
+        },
+        "fps": {
+            "min": 1,
+            "max": 10,
+            "power": -0.5
+        },
+        "res": {
+            "w": {
+                "min": 128,
+                "max": 128
+            },
+            "h": {
+                "min": 128,
+                "max": 128
+            },
+            "power": 1,
+            "snap_pow2": false
+        },
+        "quality": {
+            "min": 10,
+            "max": 95,
+            "power": 5
+        },
+        "color": {
+            "min": 32,
+            "max": 257,
+            "power": 3
+        },
+        "duration": {
+            "min": 0,
+            "max": 10000,
+            "spoof": false
+        },
+        "padding_percent": 0,
+        "bg_color": "",
+        "steps": 16,
+        "fake_vid": false,
+        "scale_filter": "bicubic",
+        "quantize_method": "imagequant",
+        "default_emoji": "😀"
+    },
     "imessage_small": {
         "size_max": {
             "img": 500000,

--- a/src/sticker_convert/resources/input.json
+++ b/src/sticker_convert/resources/input.json
@@ -109,6 +109,16 @@
             "author": true
         }
     },
+    "misskey": {
+        "full_name": "Download from Misskey",
+        "help": "Download a Misskey packed emoji ZIP as input",
+        "example": "Example: https://example.com/emojis.zip\nOR a page that links to a Misskey emoji ZIP",
+        "address_lbls": "URL address",
+        "metadata_provides": {
+            "title": true,
+            "author": true
+        }
+    },
     "local": {
         "full_name": "From local directory",
         "help": "Load files from local directory on computer",

--- a/src/sticker_convert/resources/output.json
+++ b/src/sticker_convert/resources/output.json
@@ -63,6 +63,14 @@
             "author": true
         }
     },
+    "misskey": {
+        "full_name": "Compress to Misskey packed emoji ZIP",
+        "help": "Create a Misskey packed emoji ZIP with meta.json",
+        "metadata_requirements": {
+            "title": false,
+            "author": false
+        }
+    },
     "local": {
         "full_name": "Save to local directory only",
         "help": "Save to local directory only",

--- a/src/sticker_convert/uploaders/compress_misskey.py
+++ b/src/sticker_convert/uploaders/compress_misskey.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+import copy
+import json
+import re
+import unicodedata
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+from sticker_convert.converter import StickerConvert
+from sticker_convert.job_option import CompOption, CredOption, OutputOption
+from sticker_convert.uploaders.upload_base import UploadBase
+from sticker_convert.utils.callback import CallbackProtocol, CallbackReturn
+from sticker_convert.utils.files.metadata_handler import MetadataHandler
+from sticker_convert.utils.files.sanitize_filename import sanitize_filename
+from sticker_convert.utils.media.codec_info import CodecInfo
+from sticker_convert.utils.media.format_verify import FormatVerify
+from sticker_convert.utils.translate import I
+
+
+class CompressMisskey(UploadBase):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.base_spec.set_size_max(50000)
+        self.base_spec.set_format((".png", ".gif"))
+
+        self.png_spec = copy.deepcopy(self.base_spec)
+        self.png_spec.animated = False
+        self.png_spec.set_format((".png",))
+
+        self.gif_spec = copy.deepcopy(self.base_spec)
+        self.gif_spec.animated = True
+        self.gif_spec.set_format((".gif",))
+
+        self.opt_comp_merged = copy.deepcopy(self.opt_comp)
+        self.opt_comp_merged.merge(self.base_spec)
+
+    @staticmethod
+    def _slugify(value: str) -> str:
+        normalized = unicodedata.normalize("NFKD", value)
+        ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+        slug = re.sub(r"[^a-zA-Z0-9_]+", "_", ascii_value).strip("_").lower()
+        return slug
+
+    def _get_category(self, title: str) -> str:
+        category = self._slugify(title)
+        return category or "sticker_convert"
+
+    def _get_name(self, stem: str, category: str, index: int, names_seen: Set[str]) -> str:
+        name = self._slugify(stem)
+        if not name or name.isdigit() or name in names_seen:
+            name = f"{category}_{str(index).zfill(3)}"
+
+        while name in names_seen:
+            name = f"{name}_{str(index).zfill(3)}"
+
+        names_seen.add(name)
+        return name
+
+    def compress_misskey(self) -> Tuple[int, int, List[str]]:
+        urls: List[str] = []
+        title, author, _ = MetadataHandler.get_metadata(
+            self.opt_output.dir,
+            title=self.opt_output.title,
+            author=self.opt_output.author,
+        )
+        title = title or self.opt_output.dir.name or "misskey-export"
+        category = self._get_category(title)
+
+        out_f = Path(self.opt_output.dir, sanitize_filename(title + ".zip")).as_posix()
+        stickers = MetadataHandler.get_stickers_present(self.opt_output.dir)
+
+        meta: Dict[str, Any] = {
+            "metaVersion": 2,
+            "host": author or "",
+            "exportedAt": datetime.now(timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "emojis": [],
+        }
+
+        stickers_ok = 0
+        stickers_total = len(stickers)
+        names_seen: Set[str] = set()
+        file_names_seen: Set[str] = set()
+
+        with zipfile.ZipFile(out_f, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for num, src in enumerate(stickers, start=1):
+                self.cb.put(I("Verifying {} for compressing into Misskey ZIP").format(src))
+
+                if CodecInfo.is_anim(src):
+                    expected_name = Path("bytes.gif")
+                    spec = self.gif_spec
+                else:
+                    expected_name = Path("bytes.png")
+                    spec = self.png_spec
+
+                if not FormatVerify.check_file(src, spec=spec):
+                    success, _, image_data, _ = StickerConvert.convert(
+                        src,
+                        expected_name,
+                        self.opt_comp_merged,
+                        self.cb,
+                        self.cb_return,
+                    )
+                    assert isinstance(image_data, bytes)
+                    if not success:
+                        self.cb.put(
+                            I("Warning: Cannot compress file {}, skip this file...").format(
+                                src.name
+                            )
+                        )
+                        continue
+                    file_suffix = expected_name.suffix
+                else:
+                    with open(src, "rb") as f:
+                        image_data = f.read()
+                    file_suffix = src.suffix.lower()
+
+                base_file_name = sanitize_filename(src.stem) or f"emoji_{str(num).zfill(3)}"
+                file_name = sanitize_filename(base_file_name + file_suffix)
+                while file_name in file_names_seen:
+                    file_name = sanitize_filename(
+                        f"{base_file_name}_{str(num).zfill(3)}{file_suffix}"
+                    )
+                file_names_seen.add(file_name)
+
+                emoji_name = self._get_name(src.stem, category, num, names_seen)
+                meta["emojis"].append(
+                    {
+                        "downloaded": True,
+                        "fileName": file_name,
+                        "emoji": {
+                            "name": emoji_name,
+                            "category": category,
+                            "aliases": [],
+                        },
+                    }
+                )
+                zipf.writestr(file_name, image_data)
+                stickers_ok += 1
+
+            zipf.writestr(
+                "meta.json",
+                json.dumps(meta, ensure_ascii=False, indent=2).encode("utf-8"),
+            )
+
+        self.cb.put(out_f)
+        urls.append(out_f)
+
+        return stickers_ok, stickers_total, urls
+
+    @staticmethod
+    def start(
+        opt_output: OutputOption,
+        opt_comp: CompOption,
+        opt_cred: CredOption,
+        cb: CallbackProtocol,
+        cb_return: CallbackReturn,
+    ) -> Tuple[int, int, List[str]]:
+        exporter = CompressMisskey(opt_output, opt_comp, opt_cred, cb, cb_return)
+        return exporter.compress_misskey()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,5 +1,10 @@
 import os
+import json
+import threading
+import zipfile
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import List
 
 import pytest
@@ -64,6 +69,65 @@ def _run_sticker_convert(
         assert "author.txt" in os.listdir(input_dir)
     if with_emoji:
         assert "emoji.txt" in os.listdir(input_dir)
+
+
+def test_download_misskey(tmp_path: LocalPath) -> None:
+    with TemporaryDirectory() as server_dir_name:
+        server_dir = Path(server_dir_name)
+        archive_path = server_dir / "pack.zip"
+        png_bytes = (Path(__file__).resolve().parent / "samples/static_png_RGBA_80x60.png").read_bytes()
+        gif_bytes = (Path(__file__).resolve().parent / "samples/animated_gif_160x90_1s.gif").read_bytes()
+
+        meta = {
+            "metaVersion": 2,
+            "host": "example.com",
+            "exportedAt": "2026-03-12T00:00:00.000Z",
+            "emojis": [
+                {
+                    "downloaded": True,
+                    "fileName": "alpha.png",
+                    "emoji": {"name": "example_smile", "category": "example", "aliases": []},
+                },
+                {
+                    "downloaded": True,
+                    "fileName": "wave.gif",
+                    "emoji": {"name": "example_wave", "category": "example", "aliases": []},
+                },
+            ],
+        }
+
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("meta.json", json.dumps(meta))
+            zf.writestr("alpha.png", png_bytes)
+            zf.writestr("wave.gif", gif_bytes)
+
+        class Handler(SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=server_dir_name, **kwargs)
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            _run_sticker_convert(
+                tmp_path=tmp_path,
+                source="misskey",
+                url=f"http://127.0.0.1:{server.server_port}/pack.zip",
+                expected_file_count=0,
+                expected_file_formats=[],
+                with_title=True,
+                with_author=True,
+                with_emoji=False,
+            )
+        finally:
+            server.shutdown()
+            thread.join()
+
+    input_dir = Path(tmp_path) / "input"
+    assert "example_smile.png" in os.listdir(input_dir)
+    assert "example_wave.gif" in os.listdir(input_dir)
+    assert Path(input_dir, "title.txt").read_text(encoding="utf-8").strip() == "pack"
+    assert Path(input_dir, "author.txt").read_text(encoding="utf-8").strip() == "example.com"
 
 
 @pytest.mark.skipif(not TEST_DOWNLOAD, reason="TEST_DOWNLOAD not set")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,6 +1,10 @@
+import json
 import os
 import sys
+import zipfile
 from pathlib import Path
+from shutil import copy2
+from tempfile import TemporaryDirectory
 from typing import List, Optional
 
 import pytest
@@ -172,6 +176,53 @@ def test_export_wastickers(tmp_path: LocalPath) -> None:
 
     wastickers_path = Path(tmp_path, "sticker-convert-test.wastickers")
     assert Path(wastickers_path).is_file()
+
+
+def test_export_misskey(tmp_path: LocalPath) -> None:
+    with TemporaryDirectory() as input_dir_name:
+        input_dir = Path(input_dir_name)
+        copy2(SAMPLE_DIR / "static_png_RGBA_800x600.png", input_dir / "alpha.png")
+        copy2(SAMPLE_DIR / "animated_webp_160x90_1s.webp", input_dir / "wave.webp")
+
+        run_cmd(
+            [
+                PYTHON_EXE,
+                "sticker-convert.py",
+                "--input-dir",
+                str(input_dir),
+                "--output-dir",
+                str(tmp_path),
+                "--preset",
+                "misskey",
+                "--export-misskey",
+                "--no-confirm",
+                "--author",
+                "example.com",
+                "--title",
+                "Misskey Test Pack",
+            ],
+            cwd=SRC_DIR,
+        )
+
+    export_path = Path(tmp_path, "Misskey Test Pack.zip")
+    assert export_path.is_file()
+    assert Path(tmp_path, "alpha.png").is_file()
+    assert Path(tmp_path, "wave.gif").is_file()
+
+    with zipfile.ZipFile(export_path) as zf:
+        names = zf.namelist()
+        assert "meta.json" in names
+        meta = json.loads(zf.read("meta.json"))
+        assert meta["metaVersion"] == 2
+        assert meta["host"] == "example.com"
+        assert len(meta["emojis"]) == 2
+        assert {Path(entry["fileName"]).suffix for entry in meta["emojis"]} == {
+            ".png",
+            ".gif",
+        }
+        for entry in meta["emojis"]:
+            assert entry["emoji"]["category"] == "misskey_test_pack"
+            assert zf.getinfo(entry["fileName"]).file_size <= 50000
 
 
 def test_export_line(tmp_path: LocalPath) -> None:


### PR DESCRIPTION
## Summary
- add Misskey packed-emoji download support from direct ZIP URLs or pages that link to a ZIP
- add Misskey export support with a dedicated compression preset and generated `meta.json` metadata
- cover the new download and export flows with regression tests

## Testing
- smoke-tested Misskey export and verified the generated ZIP metadata and file formats
- smoke-tested Misskey download against a temporary local HTTP server serving a synthetic Misskey pack

Closes #372.